### PR TITLE
add links to slides in overview table

### DIFF
--- a/BuildSite.R
+++ b/BuildSite.R
@@ -12,6 +12,9 @@ library(tidyverse)
   # schedule
   schedule <- readr::read_csv("import/rpharma2018_schedule.csv")
 
+  # slide links
+  slides <- readr::read_csv("import/rpharma2018_slides.csv")
+
 #### Add order
   abstracts <- abstracts %>%
     left_join(
@@ -27,8 +30,10 @@ library(tidyverse)
   abstracts <- abstracts %>%
     mutate(
       day = case_when(
-        date == "2018/8/15" ~ "Wednesday, 15th August",
-        date == "2018/8/16" ~ "Thursday, 16th August",
+        date == "15.08.18" ~ "Wednesday, 15th August",
+        date == "16.08.18" ~ "Thursday, 16th August",
+        # date == "2018/8/15" ~ "Wednesday, 15th August",
+        # date == "2018/8/16" ~ "Thursday, 16th August",
         TRUE ~ date
       ),
       when = paste0(
@@ -137,14 +142,19 @@ library(tidyverse)
         select(speaker_id,title,speakerName),
       by = "speaker_id"
     ) %>%
+    left_join(
+      slides %>%
+        select(speaker, slides),
+      by = "speaker"
+    ) %>%
     mutate(
       info  = case_when(
         type == "Tutorial" ~ paste(talk_desc,"(Workshop)"),
         type %in% c("Keynote","Talk","Lightning Talk") ~ title,
         TRUE ~ type
-      )
+      ),
+      slides = ifelse(is.na(slides), "", slides)
     )
-
 
   overview_header <- jb_readtemplate("overview_header")
 
@@ -161,13 +171,13 @@ description: R/Pharma 2018 schedule.
 ")
     # day 1
     temp <- schedule_withtalks %>%
-      filter(date == "2018/8/15")
+      filter(date == "15.08.18")
 
-      cat(paste0("| When | What | \n"))
-      cat(paste0("|----|----| \n"))
+      cat(paste0("| When | What | Slides | \n"))
+      cat(paste0("|----|----|----| \n"))
       cat(
         paste0(
-          "| **",temp$time,"** | _",temp$info,"_ |\n"
+          "| **",temp$time,"** | _",temp$info,"_ | ", temp$slides, " | \n"
         ),
         sep = ""
       )
@@ -180,10 +190,10 @@ cat("
 
     # day 2
     temp <- schedule_withtalks %>%
-      filter(date == "2018/8/16")
+      filter(date == "16.08.18")
       cat(
         paste0(
-          "* **",temp$time,"** _",temp$info,"_ \n"
+          "* **",temp$time,"** _",temp$info,"_ ", temp$slides, " \n"
         ),
         sep = ""
       )

--- a/overview.md
+++ b/overview.md
@@ -6,71 +6,71 @@ description: R/Pharma 2018 schedule.
 
 ## Wednesday
 
-| When | What | 
-|----|----| 
-| **07:30 - 09:15** | _Registration_ |
-| **08:00 - 09:00** | _Keeping things Peachy when Shiny gets Hairy (Workshop)_ |
-| **08:00 - 09:00** | _Analyzing Clinical Trials Data with R (Workshop)_ |
-| **08:00 - 09:00** | _Bayesian Models for Smaller Trial Sizes - Stan with R for analysis (Workshop)_ |
-| **08:00 - 09:00** | _Moving Fast Without Breaking Things: Navigating the R Ecosystem in an Enterprise Environment (Workshop)_ |
-| **09:15 - 09:25** | _Opening Remarks_ |
-| **09:25 - 10:10** | _Modernizing the new drug regulatory program in FDA/CDER:  Can Collaborations and Sharing Help?_ |
-| **10:10 - 10:30** | _Using R in a regulatory environment: some FDA perspectives_ |
-| **10:30 - 10:40** | _Using R in a GxP Environment_ |
-| **10:40 - 10:50** | _IDBac: A New Paradigm in Developing Microbial Libraries for Drug Discovery_ |
-| **10:50 - 11:10** | _Break_ |
-| **11:10 - 11:30** | _The largest Shiny application in the world. Roche.Diagnostics.bioWARP_ |
-| **11:30 - 11:40** | _R reproducibility by containers and cloud_ |
-| **11:40 - 11:50** | _Multi-state Model for the Analysis of an Association between Safety and Efficacy Events_ |
-| **12:10 - 13:30** | _Lunch_ |
-| **13:30 - 13:40** | _Becoming bilingual in SAS and R_ |
-| **13:40 - 13:50** | _Visualization methods for RNA-sequencing data analysis_ |
-| **13:50 - 14:00** | _The Use of R in the Development of Physiological Model for Healthy Growth_ |
-| **14:00 - 14:10** | _Antibody Characterization Using Next Generation Sequencing made easier with Group My Abs shiny app._ |
-| **14:10 - 14:20** | _Managing R and Associated Tools in Large Environments - an R-Admin’s Perspective_ |
-| **14:20 - 14:50** | _Break_ |
-| **14:50 - 15:35** | _Modeling in the tidyverse_ |
-| **15:35 - 15:55** | _ShinyRAP - a framework for analysis and building interactive/dynamic reports using Shiny/Markdown_ |
-| **15:55 - 16:05** | _Data-Driven Strategies for Synthetic Route Design and Operational Modeling within Pharmaceutical Development_ |
-| **16:05 - 16:15** | _Evaluating the performance of advanced causal inference methods applied to healthcare claims data_ |
-| **16:15 - 16:25** | _Optimization of raw materials genealogy in drug manufacturing with R, Shiny and d3_ |
-| **16:25 - 16:35** | _REAP - R-Shiny Exploratory Analysis Platform in Clinical Pharmacology_ |
-| **16:35 - 16:45** | _rOpenSci - enabling open and reproducible research_ |
-| **16:45 - 17:05** | _Moving Fast Without Breaking Things: Navigating the R Ecosystem in an Enterprise Environment_ |
-| **17:05 - 17:25** | _Beyond Simple Reproducibility - Discoverability, Provenance, and Improving the Impact of Results_ |
-| **18:00 - 19:30** | _Reception_ |
+| When | What | Slides | 
+|----|----|----| 
+| **07:30 - 09:15** | _Registration_ |  | 
+| **08:00 - 09:00** | _Keeping things Peachy when Shiny gets Hairy (Workshop)_ |  | 
+| **08:00 - 09:00** | _Analyzing Clinical Trials Data with R (Workshop)_ |  | 
+| **08:00 - 09:00** | _Stan for Pharma (Workshop)_ |  | 
+| **08:00 - 09:00** | _Moving Fast Without Breaking Things: Navigating the R Ecosystem in an Enterprise Environment (Workshop)_ |  | 
+| **09:15 - 09:25** | _Opening Remarks_ |  | 
+| **09:25 - 10:10** | _Modernizing the new drug regulatory program in FDA/CDER:  Can Collaborations and Sharing Help?_ |  | 
+| **10:10 - 10:30** | _Using R in a regulatory environment: some FDA perspectives_ |  | 
+| **10:30 - 10:40** | _Using R in a GxP Environment_ |  | 
+| **10:40 - 10:50** | _IDBac: A New Paradigm in Developing Microbial Libraries for Drug Discovery_ | https://github.com/chasemc/presentations/blob/master/RinPharma_Aug_2018/rPharma_Chase.pdf | 
+| **10:50 - 11:10** | _Break_ |  | 
+| **11:10 - 11:30** | _The largest Shiny application in the world. Roche.Diagnostics.bioWARP_ |  | 
+| **11:30 - 11:40** | _R reproducibility by containers and cloud_ |  | 
+| **11:40 - 11:50** | _Multi-state Model for the Analysis of an Association between Safety and Efficacy Events_ |  | 
+| **12:10 - 13:30** | _Lunch_ |  | 
+| **13:30 - 13:40** | _Becoming bilingual in SAS and R_ |  | 
+| **13:40 - 13:50** | _Visualization methods for RNA-sequencing data analysis_ |  | 
+| **13:50 - 14:00** | _The Use of R in the Development of Physiological Model for Healthy Growth_ |  | 
+| **14:00 - 14:10** | _Antibody Characterization Using Next Generation Sequencing made easier with Group My Abs shiny app._ |  | 
+| **14:10 - 14:20** | _Managing R and Associated Tools in Large Environments - an R-Admin’s Perspective_ |  | 
+| **14:20 - 14:50** | _Break_ |  | 
+| **14:50 - 15:35** | _Modeling in the tidyverse_ | http://appliedpredictivemodeling.com/blog/rpharma18 | 
+| **15:35 - 15:55** | _ShinyRAP - a framework for analysis and building interactive/dynamic reports using Shiny/Markdown_ |  | 
+| **15:55 - 16:05** | _Data-Driven Strategies for Synthetic Route Design and Operational Modeling within Pharmaceutical Development_ |  | 
+| **16:05 - 16:15** | _Evaluating the performance of advanced causal inference methods applied to healthcare claims data_ |  | 
+| **16:15 - 16:25** | _Optimization of raw materials genealogy in drug manufacturing with R, Shiny and d3_ | https://github.com/tcash21/talks/blob/master/TCB%20Analytics%20-%20RPharma%202018.pdf | 
+| **16:25 - 16:35** | _REAP - R-Shiny Exploratory Analysis Platform in Clinical Pharmacology_ |  | 
+| **16:35 - 16:45** | _rOpenSci - enabling open and reproducible research_ | https://github.com/ropensci/talks/tree/master/rpharma-2018 | 
+| **17:05 - 17:25** | _Beyond Simple Reproducibility - Discoverability, Provenance, and Improving the Impact of Results_ |  | 
+| **18:00 - 19:30** | _Reception_ |  | 
 
 
 ## Thursday
 
-* **07:30 - 09:15** _Registration_ 
-* **08:00 - 09:00** _Interactive data visualization with R, plotly, and dashR (Workshop)_ 
-* **08:00 - 09:00** _The Challenges of Validating R (Workshop)_ 
-* **08:00 - 09:00** _The largest Shiny application in the world. Roche.Diagnostics.bioWARP (Workshop)_ 
-* **09:15 - 09:25** _Opening Remarks_ 
-* **09:25 - 10:10** _Using interactivity responsibly in pharma_ 
-* **10:10 - 10:30** _Interactive data visualization with R, plotly, and dashR_ 
-* **10:30 - 10:50** _Developing powerful Shiny applications in an enterprise environment: Best practices and lessons learned_ 
-* **10:50 - 11:10** _Break_ 
-* **11:10 - 11:30** _NetTCR: Towards Accurate Prediction of T-cell Targets using Deep Learning_ 
-* **11:30 - 11:50** _Analyzing Clinical Trials Data with R_ 
-* **12:10 - 13:30** _Lunch_ 
-* **13:30 - 13:40** _Unification in a Compartmentalized Culture_ 
-* **13:40 - 13:50** _R4SPA: R Packages and Training to enable Statistical Programming in R_ 
-* **13:50 - 14:00** _Assisting clinical trial simulation with the use of Shiny_ 
-* **14:00 - 14:10** _R/Shiny Clinical Dashboards For Fun* and Profit *Note: Fun is Relative_ 
-* **14:10 - 14:20** _The drake R package: reproducible data analysis at scale_ 
-* **14:20 - 14:50** _Break_ 
-* **14:50 - 15:35** _Enabling open-source analytics in the enterprise_ 
-* **15:35 - 15:45** _The role of R in converting clinical trial programmers to data scientists_ 
-* **15:45 - 15:55** _Accelerate Personalized Health Care by Empowering Biomarker Data_ 
-* **15:55 - 16:05** _Keeping things Peachy when Shiny gets Hairy_ 
-* **16:05 - 16:15** _Shiny Apps in Genomics and Clinical Trials_ 
-* **16:15 - 16:25** _R as the Core Technology to Support Modeling and Simulation in Pharma Research, Development, and Post Approval Activities_ 
-* **16:25 - 16:35** _Building a community of competent developers and users of R-based tools in mass spectrometry-based research_ 
-* **16:35 - 16:45** _Bayesian Models for Smaller Trial Sizes_ 
-* **16:45 - 16:55** _Enhance R Overview_ 
-* **16:55 - 17:05** _The Magic R-Shiny App that can Boost your SDTM Usability and Viability while Saving Time_ 
-* **17:05 - 17:15** _Reproducible computational research at Eisai: leadership, technology, and culture_ 
-* **17:15 - 17:25** _The Challenges of Validating R_ 
-* **18:00 - 20:00** _Drinks_ 
+* **07:30 - 09:15** _Registration_  
+* **08:00 - 09:00** _Interactive data visualization with R, plotly, and dashR (Workshop)_  
+* **08:00 - 09:00** _The Challenges of Validating R (Workshop)_  
+* **08:00 - 09:00** _The largest Shiny application in the world. Roche.Diagnostics.bioWARP (Workshop)_  
+* **09:15 - 09:25** _Opening Remarks_  
+* **09:25 - 10:10** _Using interactivity responsibly in pharma_  
+* **10:10 - 10:30** _Interactive data visualization with R, plotly, and dashR_  
+* **10:30 - 10:50** _Developing powerful Shiny applications in an enterprise environment: Best practices and lessons learned_ http://rpodcast.gitlab.io/rpharma2018/#1 
+* **10:50 - 11:10** _Break_  
+* **11:10 - 11:30** _NetTCR: Towards Accurate Prediction of T-cell Targets using Deep Learning_  
+* **11:30 - 11:50** _Analyzing Clinical Trials Data with R_  
+* **11:50 - 12:15** _Moving Fast Without Breaking Things: Navigating the R Ecosystem in an Enterprise Environment_  
+* **12:10 - 13:30** _Lunch_  
+* **13:30 - 13:40** _Unification in a Compartmentalized Culture_  
+* **13:40 - 13:50** _R4SPA: R Packages and Training to enable Statistical Programming in R_ https://kieranjmartin.github.io/R4SPA-talk/r4spa.html#1 
+* **13:50 - 14:00** _Assisting pharmacometric simulation with the use of Shiny_  
+* **14:00 - 14:10** _R/Shiny Clinical Dashboards For Fun* and Profit *Note: Fun is Relative_  
+* **14:10 - 14:20** _The drake R package: reproducible data analysis at scale_ https://wlandau.github.io/drake-talk/#/ 
+* **14:20 - 14:50** _Break_  
+* **14:50 - 15:35** _Enabling open-source analytics in the enterprise_  
+* **15:35 - 15:45** _The role of R in converting clinical trial programmers to data scientists_ https://phcanalytics.github.io/slides/aboutus/RinPharma2018/#/ 
+* **15:45 - 15:55** _Accelerate Personalized Health Care by Empowering Biomarker Data_  
+* **15:55 - 16:05** _Keeping things Peachy when Shiny gets Hairy_  
+* **16:05 - 16:15** _Shiny Apps in Genomics and Clinical Trials_ https://jminnier-talks.netlify.com/2018_08_rpharma_shiny/minnier_rpharma2018.html#1 
+* **16:15 - 16:25** _R as the Core Technology to Support Modeling and Simulation in Pharma Research, Development, and Post Approval Activities_  
+* **16:25 - 16:35** _Building a community of competent developers and users of R-based tools in mass spectrometry-based research_  
+* **16:35 - 16:45** _Bayesian Models for Smaller Trial Sizes_  
+* **16:45 - 16:55** _Enhance R Overview_  
+* **16:55 - 17:05** _The Magic R-Shiny App that can Boost your SDTM Usability and Viability while Saving Time_  
+* **17:05 - 17:15** _Reproducible computational research at Eisai: leadership, technology, and culture_  
+* **17:15 - 17:25** _The Challenges of Validating R_  
+* **18:00 - 20:00** _Informal drinks (not formally organised)_  


### PR DESCRIPTION
This PR adds a new column for slide links in the overview table.  I created a new CSV file that I can easily add more links to as they become available.  One minor tweak I had to make is the date column was different in the CSV files than what was used in the filtering functions.  Other than that the process was smooth.  